### PR TITLE
Fixed Python examples

### DIFF
--- a/actest.html
+++ b/actest.html
@@ -27,18 +27,18 @@
 <body>
 <pre data-component="activecode" data-lang="python" id="test1">
 def foo():
-    print 'hello world'
+    print('hello world')
 
 foo()
 </pre>
 
 <pre data-component="activecode" data-lang="python" id="test2" data-include="test1 test2">
 def main():
-    print 'goodbye girl'
+    print('goodbye girl')
 
 main()
 ====
-print "This is hidden suffix code you don't see it in the editor"
+print('This is hidden suffix code you do not see it in the editor')
 </pre>
 
 


### PR DESCRIPTION
Printing died because of missing parentheses.
